### PR TITLE
Add doc generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Build Docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Install DocFX
+        run: dotnet tool update -g docfx
+      - name: Generate documentation
+        run: docfx docfx.json
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/_site
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ TestResults/
 project.lock.json
 project.fragment.lock.json
 
+docs/_site/
+

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,29 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": ["src/DSLApp1.csproj"],
+          "exclude": ["**/bin/**", "**/obj/**", "tests/**"]
+        }
+      ],
+      "dest": "api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": ["docs/**.md"],
+        "dest": "."
+      },
+      {
+        "files": ["api/**.yml"],
+        "dest": "api"
+      }
+    ],
+    "dest": "docs/_site",
+    "globalMetadata": {
+      "_appTitle": "RogueLiteDSL"
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+# RogueLite DSL Documentation
+
+Welcome! This site contains generated API reference and DSL documentation.
+
+- [DSL Syntax](DSL_Syntax.md)
+- [API Reference](api/index.md)

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,6 @@
+- name: Home
+  href: index.md
+- name: DSL Syntax
+  href: DSL_Syntax.md
+- name: API
+  href: api/index.md


### PR DESCRIPTION
## Summary
- create DocFX config
- ignore generated doc site
- add simple documentation index and TOC
- build documentation and publish to GitHub Pages using new workflow

## Testing
- `dotnet test DSLApp1.sln --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6843e2035d30832b86c768bcf7d5df31