### PR TITLE
Fix DocFX output for GitHub Pages

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -13,8 +13,13 @@
   "build": {
     "content": [
       {
-        "files": ["docs/**.md"],
+        "files": ["index.md"],
         "dest": "."
+      },
+      {
+        "files": ["docs/**.md"],
+        "exclude": ["docs/index.md"],
+        "dest": "docs"
       },
       {
         "files": ["api/**.yml"],

--- a/index.md
+++ b/index.md
@@ -1,0 +1,6 @@
+# RogueLite DSL Documentation
+
+Welcome! This site contains generated API reference and DSL documentation.
+
+- [DSL Syntax](docs/DSL_Syntax.md)
+- [API Reference](docs/api/index.md)


### PR DESCRIPTION
## Summary
- fix DocFX build output paths so index page is generated at the site root
- add root-level `index.md` for DocFX

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6843e6661ac4832b94944f8819108281