### PR TITLE
Add local documentation update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ This repository contains the RogueLite domain specific language and related tool
 The API reference and language guide are generated using [DocFX](https://dotnet.github.io/docfx/).
 
 You can view the latest generated documentation [here](https://lwplan.github.io/RogueLiteDSL/).
+
+To regenerate the docs locally run `tools/update_docs.sh` and open `docs/_site/index.html`.

--- a/tools/update_docs.sh
+++ b/tools/update_docs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v docfx >/dev/null 2>&1; then
+  if ! command -v dotnet >/dev/null 2>&1; then
+    echo "dotnet SDK is required but not installed." >&2
+    exit 1
+  fi
+  echo "DocFX not found. Installing locally..."
+  dotnet tool update -g docfx
+fi
+
+docfx docfx.json
+
+echo "Documentation generated in docs/_site"


### PR DESCRIPTION
## Summary
- add `tools/update_docs.sh` for building DocFX docs locally
- document the local docs workflow in README

## Testing
- `./tools/update_docs.sh` *(fails: dotnet SDK not installed)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e9334bf0832b80a32f60e960013b