### PR TITLE
Fix docfx output path

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -17,12 +17,14 @@
         "dest": "."
       },
       {
-        "files": ["docs/**.md"],
-        "exclude": ["docs/index.md"],
+        "src": "docs",
+        "files": ["**.md"],
+        "exclude": ["index.md"],
         "dest": "docs"
       },
       {
-        "files": ["api/**.yml"],
+        "src": "api",
+        "files": ["**.yml"],
         "dest": "api"
       }
     ],

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,3 @@
+# API Reference
+
+This section contains the generated API documentation. Use the table of contents on the left to navigate through namespaces, classes, and members.


### PR DESCRIPTION
## Summary
- ensure `update_docs.sh` generates `docs/api/index.html` by adjusting docfx paths
- add a minimal API landing page

## Testing
- `./tools/update_docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6843eb430b18832bbc568150f4960507