### PR TITLE
Fix buff syntax parsing

### DIFF
--- a/src/Dsl/DSLParser.Ability.cs
+++ b/src/Dsl/DSLParser.Ability.cs
@@ -43,10 +43,8 @@ public static partial class DslParsers
 
     // Modifier effects (many allowed)
     public static Parser<Token, EffectIR> ModifierClauseParser =>
-        Try(
-            InflictsEffectParser.Cast<EffectIR>()
-                .Or(AppliesEffectParser.Cast<EffectIR>())
-        );
+        InflictsEffectParser.Cast<EffectIR>()
+            .Or(AppliesEffectParser.Cast<EffectIR>());
 
     // Side effects (optional)
     public static Parser<Token, SideEffectsIR> SideEffectsClauseParser =>

--- a/src/Dsl/DSLParser.Applies.cs
+++ b/src/Dsl/DSLParser.Applies.cs
@@ -90,7 +90,7 @@ public static partial class DslParsers
             .Or(RoleParser.Select(c => new CompatibilityTag(c) as TargetTag));
 
 
-    public static Parser<Token, MultiplierMechanicIR> MultiplierMechanicParser =>
+    public static Parser<Token, MultiplierMechanicIR> FullMultiplierMechanicParser =>
         from type in OneOf(
             Tok.Vulnerability.ThenReturn(MultiplierMechanicType.Vulnerability),
             Tok.Protection.ThenReturn(MultiplierMechanicType.Protection),
@@ -106,6 +106,20 @@ public static partial class DslParsers
         from _ in Tok.Damage
         from when in Try(Tok.When.Then(ConditionParser)).Optional()
         select new MultiplierMechanicIR(type, amount.GetValueOrDefault(), against, when.GetValueOrDefault());
+
+    public static Parser<Token, MultiplierMechanicIR> SimpleMultiplierMechanicParser =>
+        from type in OneOf(
+            Tok.Vulnerability.ThenReturn(MultiplierMechanicType.Vulnerability),
+            Tok.Protection.ThenReturn(MultiplierMechanicType.Protection),
+            Tok.Power.ThenReturn(MultiplierMechanicType.Power),
+            Tok.Frailty.ThenReturn(MultiplierMechanicType.Frailty)
+        )
+        from amount in Tok.LParen.Then(AmountLiteral).Before(Tok.RParen)
+        select new MultiplierMechanicIR(type, amount, new ElementTag(Element.None), null);
+
+    public static Parser<Token, MultiplierMechanicIR> MultiplierMechanicParser =>
+        Try(FullMultiplierMechanicParser)
+            .Or(SimpleMultiplierMechanicParser);
 
 
     public static Parser<Token, StatBuffMechanicIR> StatBuffMechanicParser =>


### PR DESCRIPTION
## Summary
- fail on invalid Applies Buff syntax by letting modifier parsing error out
- parse simple vulnerability multiplier syntax without `to` or `against` clauses

## Testing
- `dotnet test tests/DSLApp1.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6843f6fa9c88832b959e20968966877f