### PR TITLE
Fix ability parser colon requirement

### DIFF
--- a/src/Dsl/DSLParser.Ability.cs
+++ b/src/Dsl/DSLParser.Ability.cs
@@ -63,9 +63,9 @@ public static partial class DslParsers
             from _lparen in Tok.LParen
             from role in RoleParser
             from _rparen in Tok.RParen
-            from _colon in Tok.Colon
             select role
         ).Optional()
+        from _colon in Tok.Colon
 
         // Optional clauses in order
         from charges in ChargesClauseParser.Optional()

--- a/tests/AbilityParserTests.cs
+++ b/tests/AbilityParserTests.cs
@@ -31,5 +31,17 @@ namespace DSLApp1.Tests.Dsl
 
 
         }
+
+        [Fact]
+        public void AbilityParser_Parses_NoRole_WithColon()
+        {
+            const string src =
+                "Ability : Deals Dark Physical(20) damage miss if roll < 80";
+
+            var tokens = DslTokenizer.Tokenize(src);
+            var ability = DslParsers.AbilityParser.ParseOrThrow(tokens);
+
+            Assert.Empty(ability.RoleCompatibilities);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- require colon after `Ability` token regardless of role
- add test for ability with no role but trailing colon

## Testing
- `dotnet test` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843fc780d60832b91c490e6d7e3c4c3