### PR TITLE
Support targeting mechanics in parser

### DIFF
--- a/docs/DSL_Syntax.md
+++ b/docs/DSL_Syntax.md
@@ -79,7 +79,10 @@ multiplier-mechanic := ('Vulnerability' | 'Protection' | 'Power' | 'Frailty') ('
 Targeting controls which units an ability can affect.  When present it specifies an automatic strategy, an optional target type, and the target side:
 
 ```ebnf
-auto-targeting-clause := 'Targeting' target-selection-criteria targetability
+auto-targeting-clause := 'Targeting' target-selection-criteria targetability ['with' targeting-mechanic { ',' targeting-mechanic } ]
+
+targeting-mechanic := targeting-mechanic-type ['(' amount ')']
+targeting-mechanic-type := 'MultiHit' | 'MultiTarget' | 'Random'
 ```
 
 Side effects occur after the main effects resolve and can include mechanics like `Bounce` or `Splash`:

--- a/src/Dsl/Grammar.txt
+++ b/src/Dsl/Grammar.txt
@@ -45,7 +45,10 @@ invoke-mechanic-type := 'Swap' | 'Shuffle' | 'Advance' | 'Delay'
 
 inflicts-clause := 'Inflicts' damage-clause [auto-targeting-clause] duration-clause ['if' condition]
 
-auto-targeting-clause := 'Targeting' target-selection-criteria targetabilty 
+auto-targeting-clause := 'Targeting' target-selection-criteria targetabilty ['with' targeting-mechanic { ',' targeting-mechanic } ]
+
+targeting-mechanic := targeting-mechanic-type ['(' amount ')']
+targeting-mechanic-type := 'MultiHit' | 'MultiTarget' | 'Random'
 
 target-selection-criteria = 'Strongest' | 'Weakest' | 'NextUp' | 'LastUp' | 'Random'
 


### PR DESCRIPTION
## Summary
- extend grammar for `Targeting` clause with optional mechanics
- add `TargetingMechanicsType` enum and `TargetingMechanic` record
- parse `with` clause for targeting mechanics
- document new grammar additions

## Testing
- `dotnet test -v minimal` *(fails: 22, passed: 134)*

------
https://chatgpt.com/codex/tasks/task_e_6844149cdf94832bb801a984c0285cca