### PR TITLE
Add Kill damage mechanic

### DIFF
--- a/src/Dsl/DSLParser.DamageEffect.cs
+++ b/src/Dsl/DSLParser.DamageEffect.cs
@@ -10,7 +10,8 @@ public enum DamageMechanicType
     Spiral,
     ExtraDamage,
     Crit,
-    ShieldBreaker
+    ShieldBreaker,
+    Kill
 }
 
 public record DamageType(DamageFormula DamageFormula, Element Element, int BaseDamage);
@@ -36,7 +37,8 @@ public static partial class DslParsers
         Tok.Spiral.ThenReturn(DamageMechanicType.Spiral),
         Tok.ExtraDamage.ThenReturn(DamageMechanicType.ExtraDamage),
         Tok.Crit.ThenReturn(DamageMechanicType.Crit),
-        Tok.ShieldBreaker.ThenReturn(DamageMechanicType.ShieldBreaker)
+        Tok.ShieldBreaker.ThenReturn(DamageMechanicType.ShieldBreaker),
+        Tok.Kill.ThenReturn(DamageMechanicType.Kill)
     );
 
     public static Parser<Token, DamageMechanic> DamageMechanicAtom =>

--- a/src/Dsl/DSLParser.Tok.cs
+++ b/src/Dsl/DSLParser.Tok.cs
@@ -127,6 +127,7 @@ namespace DSLApp1.Dsl
             public static readonly Parser<Token, Token> Target = Keyword("Target");
             public static readonly Parser<Token, Token> Missed = Keyword("Missed");
             public static readonly Parser<Token, Token> Kills = Keyword("Kills");
+            public static readonly Parser<Token, Token> Kill = Keyword("Kill");
             public static readonly Parser<Token, Token> Hits = Keyword("Hits");
             public static readonly Parser<Token, Token> On = Keyword("On");
             

--- a/tests/AbilityParserTests.cs
+++ b/tests/AbilityParserTests.cs
@@ -43,5 +43,19 @@ namespace DSLApp1.Tests.Dsl
 
             Assert.Empty(ability.RoleCompatibilities);
         }
+
+        [Fact]
+        public void AbilityParser_Parses_Kill_Damage_Mechanic()
+        {
+            const string src =
+                "Ability (Execution): Deals Physical(0) damage with Kill if target hpPercent < 15";
+
+            var tokens = DslTokenizer.Tokenize(src);
+            var ability = DslParsers.AbilityParser.ParseOrThrow(tokens);
+
+            var dmgEffect = Assert.IsType<DamageEffectIR>(Assert.Single(ability.Effects));
+            var mechanic = Assert.Single(dmgEffect.With);
+            Assert.Equal(DamageMechanicType.Kill, mechanic.MechanicType);
+        }
     }
 }

--- a/tests/SupportEffectParserTests.cs
+++ b/tests/SupportEffectParserTests.cs
@@ -90,5 +90,16 @@ namespace DSLApp1.Tests.Dsl
             Assert.Equal(25f, spiral.Value);
         }
 
+        [Fact]
+        public void Parses_Kill_Damage_Mechanic()
+        {
+            var effects = ParseSupportEffects("Kill(1)");
+            var effect = Assert.Single(effects);
+            var dmg = Assert.IsType<DamageSupportIR>(effect);
+
+            Assert.Equal(DamageMechanicType.Kill, dmg.Mechanic);
+            Assert.Equal(1f, dmg.Value);
+        }
+
     }
 }

--- a/tests/TestData/abilities.csv
+++ b/tests/TestData/abilities.csv
@@ -78,7 +78,7 @@ Last Words,Yes,"When a target dies,  gain 10 mana.",Ability (Execution): Restore
 Axe Man,Yes,Heavy strike that splash enemies if it kills the target.,Ability (Execution): Deals Physical(10) damage afterwards Splash if kills > 0,OK,,,
 Fatal Mark,Yes,Marks an enemy: the next attack deals double damage,Ability (Execution): Applies Vulnerability(200) until hit,OK,,,
 Killing Blow (Splash),Yes,Physical attack on a kill 50% of damage applied to all enemies.,Ability (Execution): Deals Physical(10) damage afterwards Splash(50%) if kills > 0,OK,,,
-Farewell,Yes,if the enemy is 15% or less HP you immediately kill him.,Ability (Execution): Deals Physical(0) with Kill if target hpPercent < 15,OK,,,
+Farewell,Yes,if the enemy is 15% or less HP you immediately kill him.,Ability (Execution): Deals Physical(0) damage with Kill if target hpPercent < 15,OK,,,
 Killing Blow (Bounce),Yes,"If this attack kills the target, deal 50% of that damage to a second random enemy.",Ability (Execution): Deals Physical(10) damage afterwards Bounce(50%) if kills > 0,#ERROR!,,,
 Sacred Light,Yes,Heals all allies for 20 HP.,Ability (Holy): Targeting Allies Heals(20),OK,,,
 Holy Armor,Yes,Grants +6 Defense for 3 turns.,"Ability (Holy): Applies Buff(DEF,6) for 3 turns",#ERROR!,,,


### PR DESCRIPTION
## Summary
- support `Kill` as a damage mechanic
- update token list
- test parsing abilities/support mechanics with `Kill`
- fix CSV data to include the `damage` keyword

## Testing
- `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68441c41ce04832bb825a96b5d7963dc