### PR TITLE
Fix Camouflage DSL syntax

### DIFF
--- a/tests/TestData/abilities.csv
+++ b/tests/TestData/abilities.csv
@@ -19,7 +19,7 @@ Radiating light,Pass,midrange healing with regeneration I,Ability (Holy): Restor
 Waterfall meditation,Pass,Applies a small range selfheal and applies Surge II,Ability (Holy): Targeting Self Restores 8 hp then Applies @Surge[II] for 2 turns,,,,
 Ice bolas,Pass,"Physical water skill which exhaust, applies Slow III",Ability : Deals Water Physical(8) damage with Exhaust then Applies @Slow[III] for 2 turns,,,,
 Holy Smite,Pass,A blast of holy light,Ability (Holy): Deals Light Magical(15) damage,,,,
-Camouflage,Pass,Applies a powerful buff so the next attack is Charge III,"Ability : Targeting Self, Apply @Charge[III] for 1 turn",,,,
+Camouflage,Pass,Applies a powerful buff so the next attack is Charge III,"Ability : Targeting Self Applies @Charge[III] for 1 turn",,,,
 Desert Javeline,Pass,A moderate earth physical skill which deals big damage,Ability : Deals Earth Physical(18) damage,,,,
 Nomad care,Pass,"moderate selfhealing, double potency if low hp*",Ability : Restores 10 hp then Restores 10 hp if Target HpPercent < 50,,,,
 Oil vial,Pass,"Leaves enemies oiled, which lowers their initiative and more vulnerable to fire",Ability : Applies Oiled for 3 turns then Applies Vulnerability(125%) to Fire damage for 3 turns,,,,


### PR DESCRIPTION
## Summary
- fix Camouflage row in `abilities.csv` to use `Applies` keyword

## Testing
- `dotnet test tests/DSLApp1.Tests.csproj --no-build -v minimal` *(fails: expected/known issues)*

------
https://chatgpt.com/codex/tasks/task_e_684448915750832ba680c3b0507d4ff1