### PR TITLE
Add Wet & Oiled state mechanics parsing

### DIFF
--- a/docs/DSL_Syntax.md
+++ b/docs/DSL_Syntax.md
@@ -76,7 +76,7 @@ Modifier mechanics can represent stat buffs, multipliers (e.g., `Vulnerability`)
 
 ```ebnf
 modifier-mechanic := stat-buff-mechanic | multiplier-mechanic | state-mechanic
-state-mechanic := ('Blessing' | 'Curse' | 'Stun' | 'Defensive' | 'Revival') [mechanic-specifier]
+state-mechanic := ('Blessing' | 'Curse' | 'Stun' | 'Defensive' | 'Revival' | 'Shield' | 'Wet' | 'Oiled') [mechanic-specifier]
 multiplier-mechanic := ('Vulnerability' | 'Protection' | 'Power' | 'Frailty') ['(' amount ')'] [('against' | 'to') (element | compatibility) damage] ['when' condition]
 stat-buff-mechanic := ('Buff' | 'Debuff') '(' amount ')' 'to' stat-field
 stat-field := 'Attack' | 'Defense' | 'Intelligence' | 'Resistance' | 'Initiative'

--- a/src/Dsl/AlphaWordValidator.cs
+++ b/src/Dsl/AlphaWordValidator.cs
@@ -22,7 +22,7 @@ namespace DSLApp1.Dsl
                 "Magical","to","ExtraDamage","Crit","ShieldBreaker","MultiHit",
                 "MultiTarget","Random","turns","rounds","turn","round","Start","End",
                 "Buff","Debuff","Vulnerability","Protection","Power","Frailty",
-                "Blessing","Curse","Stun","Defensive","Revival","Shield","Cleanse",
+                "Blessing","Curse","Stun","Defensive","Revival","Shield","Wet","Oiled","Cleanse",
                 "Bounce","Splash","Exhaust","CoolOff","Invokes","Delay","Advance",
                 "Swap","Shuffle","All","Miss","Attack","Defense","Intelligence",
                 "Resistance","Initiative","Applies","Mana","Hp","HpPercent",

--- a/src/Dsl/DSLParser.Applies.cs
+++ b/src/Dsl/DSLParser.Applies.cs
@@ -81,7 +81,9 @@ public static partial class DslParsers
             Tok.Stun.ThenReturn(StateMechanicType.Stun),
             Tok.Defensive.ThenReturn(StateMechanicType.Defensive),
             Tok.Revival.ThenReturn(StateMechanicType.Revival),
-            Tok.Shield.ThenReturn(StateMechanicType.Shield)
+            Tok.Shield.ThenReturn(StateMechanicType.Shield),
+            Tok.Wet.ThenReturn(StateMechanicType.Wet),
+            Tok.Oiled.ThenReturn(StateMechanicType.Oiled)
         )
         from amount in Try(Tok.LParen.Then(AmountLiteral).Before(Tok.RParen)).Optional()
         from when in Try(Tok.When.Then(ConditionBodyParser)).Optional()

--- a/src/Dsl/DSLParser.Tok.cs
+++ b/src/Dsl/DSLParser.Tok.cs
@@ -93,6 +93,8 @@ namespace DSLApp1.Dsl
             public static readonly Parser<Token, Token> Defensive = Keyword("Defensive");
             public static readonly Parser<Token, Token> Revival = Keyword("Revival");
             public static readonly Parser<Token, Token> Shield = Keyword("Shield");
+            public static readonly Parser<Token, Token> Wet = Keyword("Wet");
+            public static readonly Parser<Token, Token> Oiled = Keyword("Oiled");
             public static readonly Parser<Token, Token> Cleanse = Keyword("Cleanse");
             
             public static readonly Parser<Token, Token> Bounce = Keyword("Bounce");

--- a/src/Dsl/Grammar.txt
+++ b/src/Dsl/Grammar.txt
@@ -64,7 +64,7 @@ applies-clause := 'Applies' modifier-mechanic {',' modifier-mechanic} [duration-
 
 modifier-mechanic := stat-buff-mechanic | multiplier-mechanic | state-mechanic
 
-state-mechanic:= ('Blessing' | 'Curse' | 'Stun' | 'Defensive' | 'Revival' ) [mechanic-specifier] 
+state-mechanic:= ('Blessing' | 'Curse' | 'Stun' | 'Defensive' | 'Revival' | 'Shield' | 'Wet' | 'Oiled' ) [mechanic-specifier]
 
 multiplier-mechanic := ('Vulnerability' | 'Protection' | 'Power' | 'Frailty'  ) ('against' | 'to' )  ['(' amount ')'] ( element | compatibility ) damage ['when' condition]
 


### PR DESCRIPTION
## Summary
- support `Wet` and `Oiled` keywords in DSL tokenizer
- parse the new state mechanics
- whitelist the new keywords
- document grammar updates

## Testing
- `dotnet test` *(fails: 10, passed: 252)*

------
https://chatgpt.com/codex/tasks/task_e_68447233dcdc832bbb40baeda8c87da0