### PR TITLE
Add missing Protector role

### DIFF
--- a/src/Dsl/AlphaWordValidator.cs
+++ b/src/Dsl/AlphaWordValidator.cs
@@ -17,7 +17,7 @@ namespace DSLApp1.Dsl
                 "Afterwards","Ability","Inflicts","Deals","With","Physical","damage",
                 "For","Charges","Adds","If","Against","When","roll","Fire","Poison",
                 "Ice","Water","Earth","Dark","Light","Electrical","then","Support",
-                "Outfit","Spiral","Artillery","Brute","Nomad","Chaos","Execution","Holy",
+                "Outfit","Spiral","Artillery","Brute","Nomad","Chaos","Execution","Holy","Protector",
                 "Piercing","Adjective","Self","Ally","Allies","Enemy","Enemies",
                 "Magical","to","ExtraDamage","Crit","ShieldBreaker","MultiHit",
                 "MultiTarget","Random","turns","rounds","turn","round","Start","End",

--- a/src/Dsl/DSLParser.Header.cs
+++ b/src/Dsl/DSLParser.Header.cs
@@ -14,9 +14,10 @@ using System.Runtime.InteropServices;
      Nomad,
      Chaos,
      Blessing,
-     Execution,
-     Holy
- }
+    Execution,
+    Holy,
+    Protector
+}
  
  public record Header(HexType Type, Compatibility? Compatibility);
  
@@ -28,11 +29,12 @@ using System.Runtime.InteropServices;
          Tok.Brute.ThenReturn(Compatibility.Brute),
          Tok.Artillery.ThenReturn(Compatibility.Artillery),
          Tok.Nomad.ThenReturn(Compatibility.Nomad),
-         Tok.Chaos.ThenReturn(Compatibility.Chaos),
-         Tok.Blessing.ThenReturn(Compatibility.Blessing),
-         Tok.Execution.ThenReturn(Compatibility.Execution),
-         Tok.Holy.ThenReturn(Compatibility.Holy)
-     );
+        Tok.Chaos.ThenReturn(Compatibility.Chaos),
+        Tok.Blessing.ThenReturn(Compatibility.Blessing),
+        Tok.Execution.ThenReturn(Compatibility.Execution),
+        Tok.Holy.ThenReturn(Compatibility.Holy),
+        Tok.Protector.ThenReturn(Compatibility.Protector)
+    );
      
      public static Parser<Token, Header> HeaderParser =>
          from type in OneOf(

--- a/src/Dsl/DSLParser.Tok.cs
+++ b/src/Dsl/DSLParser.Tok.cs
@@ -53,6 +53,7 @@ namespace DSLApp1.Dsl
             public static readonly Parser<Token, Token> Chaos = Keyword("Chaos");
             public static readonly Parser<Token, Token> Execution = Keyword("Execution");
             public static readonly Parser<Token, Token> Holy = Keyword("Holy");
+            public static readonly Parser<Token, Token> Protector = Keyword("Protector");
             public static readonly Parser<Token, Token> Piercing = Keyword("Piercing");
             public static readonly Parser<Token, Token> Adjective = Keyword("Adjective");
 


### PR DESCRIPTION
## Summary
- support abilities tagged with the `Protector` role
- register `Protector` as a valid keyword

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68447533c2e8832bad0b0f31d1ddaabc