### PR TITLE
Add Outfit hex type and Equips alias

### DIFF
--- a/src/Dsl/AlphaWordValidator.cs
+++ b/src/Dsl/AlphaWordValidator.cs
@@ -25,7 +25,7 @@ namespace DSLApp1.Dsl
                 "Blessing","Curse","Stun","Defensive","Revival","Shield","Wet","Oiled","Cleanse",
                 "Bounce","Splash","Exhaust","CoolOff","Invokes","Delay","Advance",
                 "Swap","Shuffle","All","Miss","Attack","Defense","Intelligence",
-                "Resistance","Initiative","Applies","Mana","Hp","HpPercent",
+                "Resistance","Initiative","Applies","Equips","and","Mana","Hp","HpPercent",
                 "Opportunity","User","Target","Missed","Kills","Kill","Hits","On",
                 "Restores","Drains","Gives","Takes","Targeting","UserSelected",
                 "Neutral","Strongest","Weakest","NextUp","LastUp","Single","Multiple"

--- a/src/Dsl/DSLParser.Applies.cs
+++ b/src/Dsl/DSLParser.Applies.cs
@@ -170,7 +170,7 @@ public static partial class DslParsers
 
 
     public static Parser<Token, ModifierEffectIR> AppliesEffectParser =>
-        from _ in Tok.Applies
+        from _ in OneOf(Tok.Applies, Tok.Equips)
         from result in Try(
             from quoted in QuotedImmediateEffectParser
             from duration in DurationClauseParser
@@ -180,7 +180,7 @@ public static partial class DslParsers
                 new EffectModifierIR(duration, quoted, condition.GetValueOrDefault())
             )
         ).Or(
-            from mechanics in ModifierMechanicParser.Separated(Tok.Comma)
+            from mechanics in ModifierMechanicParser.Separated(OneOf(Tok.Comma, Tok.And))
             from duration in Try(DurationClauseParser).Optional()
             from condition in Try(ConditionParser).Optional()
             select new ModifierEffectIR(

--- a/src/Dsl/DSLParser.Hex.cs
+++ b/src/Dsl/DSLParser.Hex.cs
@@ -14,6 +14,7 @@ public static partial class DslParsers
     public static Parser<Token, object> HexParser =>
         Try(AbilityParser.Select(a => (object)a))
             .Or(SupportParser.Select(s => (object)s))
+            .Or(OutfitParser.Select(o => (object)o))
             .Before(Tok.EOF);
 
 }

--- a/src/Dsl/DSLParser.Outfit.cs
+++ b/src/Dsl/DSLParser.Outfit.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using Pidgin;
+using static Pidgin.Parser;
+
+namespace DSLApp1.Dsl;
+
+public record OutfitIR(
+    List<ModifierEffectIR> Effects,
+    List<Compatibility> RoleCompatibilities
+);
+
+public static partial class DslParsers
+{
+    public static Parser<Token, OutfitIR> OutfitParser =>
+        from _outfit in Tok.Outfit
+        from role in Try(
+            Tok.LParen.Then(RoleParser).Before(Tok.RParen)
+        ).Optional()
+        from _colon in Tok.Colon
+        from effects in AppliesEffectParser.Separated(Tok.Then).Select(e => e.ToList())
+        select new OutfitIR(
+            effects,
+            role.HasValue ? new List<Compatibility>{ role.Value } : new List<Compatibility>()
+        );
+}

--- a/src/Dsl/DSLParser.Tok.cs
+++ b/src/Dsl/DSLParser.Tok.cs
@@ -120,6 +120,8 @@ namespace DSLApp1.Dsl
             public static readonly Parser<Token, Token> Initiative = Keyword("Initiative");
             
             public static readonly Parser<Token, Token> Applies = Keyword("Applies");
+            public static readonly Parser<Token, Token> Equips = Keyword("Equips");
+            public static readonly Parser<Token, Token> And = Keyword("and");
 
 
             

--- a/tests/OutfitParserTests.cs
+++ b/tests/OutfitParserTests.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using DSLApp1.Dsl;
+using Pidgin;
+using Xunit;
+
+namespace DSLApp1.Tests.Dsl
+{
+    public class OutfitParserTests
+    {
+        [Fact]
+        public void Parses_Basic_Outfit_Equips()
+        {
+            const string text = "Outfit : Equips Buff(6) to Defense and Buff(6) to Resistance";
+            var tokens = DslTokenizer.Tokenize(text);
+            var outfit = DslParsers.OutfitParser.ParseOrThrow(tokens);
+            Assert.Single(outfit.Effects);
+            var applies = Assert.IsType<AppliesModifierIR>(outfit.Effects[0].Modifier);
+            Assert.Equal(2, applies.Mechanics.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Equips` and `and` keywords
- support Outfit hex type that parses `Equips` like `Applies`
- allow `Equips` as alias for `Applies` and accept `and` as a mechanic separator
- extend the Hex parser to handle Outfit blocks
- add basic Outfit parser tests

## Testing
- `dotnet test tests/DSLApp1.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684497f8fef8832b81e86dec4e28e3af